### PR TITLE
Add triage workflow to Github Actions

### DIFF
--- a/.github/workflows/add_new_issues_to_project.yml
+++ b/.github/workflows/add_new_issues_to_project.yml
@@ -6,18 +6,20 @@ jobs:
   Move_Bug_To_Triage_Board:
     runs-on: ubuntu-latest
     steps:
-    - uses: aareet/move-labeled-or-milestoned-issue@v2.0
+    - uses: aareet/move-labeled-or-milestoned-issue@v2.1
       with:
         action-token: "${{ secrets.k8s_github_actions }}"
         project-url: "https://github.com/orgs/terraform-providers/projects/19"
         column-name: "Needs triage"
         label-name: "bug"
+        add-as-note: "true"
   Move_Feature_Request_To_Triage_Board:
     runs-on: ubuntu-latest
     steps:
-    - uses: aareet/move-labeled-or-milestoned-issue@v2.0
+    - uses: aareet/move-labeled-or-milestoned-issue@v2.1
       with:
         action-token: "${{ secrets.k8s_github_actions }}"
         project-url: "https://github.com/orgs/terraform-providers/projects/19"
         column-name: "Needs triage"
         label-name: "enhancement"
+        add-as-note: "true"

--- a/.github/workflows/add_new_issues_to_project.yml
+++ b/.github/workflows/add_new_issues_to_project.yml
@@ -1,0 +1,23 @@
+name: Automate labeled issues
+on:
+  issues:
+    types: [labeled]
+jobs:
+  Move_Bug_To_Triage_Board:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: aareet/move-labeled-or-milestoned-issue@v2.0
+      with:
+        action-token: "${{ secrets.k8s_github_actions }}"
+        project-url: "https://github.com/orgs/terraform-providers/projects/19"
+        column-name: "Needs triage"
+        label-name: "bug"
+  Move_Feature_Request_To_Triage_Board:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: aareet/move-labeled-or-milestoned-issue@v2.0
+      with:
+        action-token: "${{ secrets.k8s_github_actions }}"
+        project-url: "https://github.com/orgs/terraform-providers/projects/19"
+        column-name: "Needs triage"
+        label-name: "enhancement"


### PR DESCRIPTION
Adds a github workflow to automatically add new issues to the triage board for review.