### PR TITLE
fix v0.1.3-alpha version string

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: terraform
-version: 0.1.0-alpha
+version: 0.1.3-alpha
 description: Install and configure Terraform Cloud Operator on Kubernetes.
 home: https://www.terraform.io
 sources:

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: terraform
-version: 0.1.0
+version: 0.1.0-alpha
 description: Install and configure Terraform Cloud Operator on Kubernetes.
 home: https://www.terraform.io
 sources:


### PR DESCRIPTION
To signify a prerelease, the version string should be[ Semver2 compliant](https://semver.org/#spec-item-9). Prereleases are hidden from the `helm search repo` command unless a user specifies the [`--devel` flag.](https://helm.sh/docs/helm/helm_search_repo/#synopsis) 

Before:
```
$ helm package .
Successfully packaged chart and saved it to: /Users/ahuang/terraform-helm/terraform-0.1.0.tg
$ helm repo index .
$ helm repo add local http://localhost:3000
$ helm search repo local -l
NAME            CHART VERSION   APP VERSION     DESCRIPTION                 
local/terraform 0.1.0                           Install and configure Terraform Cloud Operator ...
```

After:
```
$ git diff
diff --git a/Chart.yaml b/Chart.yaml
index 968c1f4..179cd0c 100644
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: terraform
-version: 0.1.0
+version: 0.1.0-alpha
 description: Install and configure Terraform Cloud Operator on Kubernetes.
 home: https://www.terraform.io
 sources:
$ helm repo update
Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "local" chart repository
Update Complete. ⎈ Happy Helming!⎈
$ helm search repo local -l
No results found
$ helm search repo local -l --devel
NAME            CHART VERSION   APP VERSION     DESCRIPTION
local/terraform 0.1.0-alpha                     Install and configure Terraform Cloud Operator ...
```