### PR TITLE
Fix unit tests

### DIFF
--- a/test/docker/Test.dockerfile
+++ b/test/docker/Test.dockerfile
@@ -43,7 +43,7 @@ RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s
     mv ./kubectl /usr/local/bin/kubectl
 
 # helm
-RUN curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get | bash
+RUN curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
 
 # bats
 RUN curl -sSL https://github.com/bats-core/bats-core/archive/v${BATS_VERSION}.tar.gz -o /tmp/bats.tgz \

--- a/test/module/random.tf
+++ b/test/module/random.tf
@@ -1,0 +1,33 @@
+variable "hellos" {
+  type = object({
+    hello        = string
+    second_hello = string
+  })
+  description = "list of hellos"
+}
+
+variable "secret_key" {
+  type        = string
+  description = "this is a secret"
+}
+
+resource "random_pet" "server" {
+  keepers = {
+    hello      = var.hellos.hello
+    secret_key = var.secret_key
+  }
+}
+
+resource "random_pet" "number_2" {
+  keepers = {
+    hello = var.hellos.second_hello
+  }
+}
+
+output "pet" {
+  value = random_pet.server.id
+}
+
+output "list_of_pets" {
+  value = [random_pet.server.id, random_pet.number_2.id]
+}

--- a/test/module/random.tf
+++ b/test/module/random.tf
@@ -6,15 +6,15 @@ variable "hellos" {
   description = "list of hellos"
 }
 
-variable "secret_key" {
+variable "some_key" {
   type        = string
-  description = "this is a secret"
+  description = "this is a some key"
 }
 
 resource "random_pet" "server" {
   keepers = {
     hello      = var.hellos.hello
-    secret_key = var.secret_key
+    secret_key = var.some_key
   }
 }
 

--- a/test/unit/sync-workspace-deployment.bats
+++ b/test/unit/sync-workspace-deployment.bats
@@ -2,13 +2,13 @@
 
 load _helpers
 
-@test "syncWorkspace/Deployment: disabled by default" {
+@test "syncWorkspace/Deployment: enabled by default" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/sync-workspace-deployment.yaml  \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
+  [ "${actual}" = "true" ]
 }
 
 @test "syncWorkspace/Deployment: enable with global.enabled false" {

--- a/test/unit/sync-workspace-deployment.bats
+++ b/test/unit/sync-workspace-deployment.bats
@@ -5,7 +5,7 @@ load _helpers
 @test "syncWorkspace/Deployment: enabled by default" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/sync-workspace-deployment.yaml  \
+      --show-only templates/sync-workspace-deployment.yaml  \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
@@ -14,7 +14,7 @@ load _helpers
 @test "syncWorkspace/Deployment: enable with global.enabled false" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/sync-workspace-deployment.yaml  \
+      --show-only templates/sync-workspace-deployment.yaml  \
       --set 'global.enabled=false' \
       --set 'syncWorkspace.enabled=true' \
       . | tee /dev/stderr |
@@ -25,7 +25,7 @@ load _helpers
 @test "syncWorkspace/Deployment: disable with syncWorkspace.enabled" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/sync-workspace-deployment.yaml  \
+      --show-only templates/sync-workspace-deployment.yaml  \
       --set 'syncWorkspace.enabled=false' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
@@ -35,7 +35,7 @@ load _helpers
 @test "syncWorkspace/Deployment: disable with global.enabled" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/sync-workspace-deployment.yaml  \
+      --show-only templates/sync-workspace-deployment.yaml  \
       --set 'global.enabled=false' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
@@ -48,7 +48,7 @@ load _helpers
 @test "syncWorkspace/Deployment: image defaults to global.imageK8S" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/sync-workspace-deployment.yaml  \
+      --show-only templates/sync-workspace-deployment.yaml  \
       --set 'global.imageK8S=bar' \
       --set 'syncWorkspace.enabled=true' \
       . | tee /dev/stderr |
@@ -59,7 +59,7 @@ load _helpers
 @test "syncWorkspace/Deployment: image can be overridden with syncWorkspace.image" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/sync-workspace-deployment.yaml  \
+      --show-only templates/sync-workspace-deployment.yaml  \
       --set 'global.imageK8S=foo' \
       --set 'syncWorkspace.enabled=true' \
       --set 'syncWorkspace.image=bar' \
@@ -74,7 +74,7 @@ load _helpers
 @test "syncWorkspace/Deployment: watch namespace defaults to release namespace" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/sync-workspace-deployment.yaml  \
+      --show-only templates/sync-workspace-deployment.yaml  \
       --set 'syncWorkspace.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].command | any(contains("--k8s-watch-namespace=\"default\""))' | tee /dev/stderr)
@@ -84,7 +84,7 @@ load _helpers
 @test "syncWorkspace/Deployment: watch namespace can be overridden" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/sync-workspace-deployment.yaml  \
+      --show-only templates/sync-workspace-deployment.yaml  \
       --set 'syncWorkspace.enabled=true' \
       --set 'syncWorkspace.k8WatchNamespace=dev' \
       . | tee /dev/stderr |
@@ -98,7 +98,7 @@ load _helpers
 @test "syncWorkspace/Deployment: serviceAccount set when sync enabled" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/sync-workspace-deployment.yaml  \
+      --show-only templates/sync-workspace-deployment.yaml  \
       --set 'syncWorkspace.enabled=true' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.serviceAccountName | contains("sync-workspace")' | tee /dev/stderr)
@@ -111,7 +111,7 @@ load _helpers
 @test "syncWorkspace/Deployment: add terraformrc secrets name" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/sync-workspace-deployment.yaml  \
+      --show-only templates/sync-workspace-deployment.yaml  \
       --set 'syncWorkspace.enabled=true' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.volumes[0].secret.secretName | contains("terraformrc")' | tee /dev/stderr)
@@ -121,7 +121,7 @@ load _helpers
 @test "syncWorkspace/Deployment: add terraformrc secrets key" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/sync-workspace-deployment.yaml  \
+      --show-only templates/sync-workspace-deployment.yaml  \
       --set 'syncWorkspace.enabled=true' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.volumes[0].secret.items[0].key | contains("credentials")' | tee /dev/stderr)
@@ -131,7 +131,7 @@ load _helpers
 @test "syncWorkspace/Deployment: terraformrc secrets variables can be overridden" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/sync-workspace-deployment.yaml  \
+      --show-only templates/sync-workspace-deployment.yaml  \
       --set 'syncWorkspace.enabled=true' \
       --set 'syncWorkspace.terraformRC.secretName=terraformfile' \
       . | tee /dev/stderr |
@@ -142,7 +142,7 @@ load _helpers
 @test "syncWorkspace/Deployment: add workspace secrets variables" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/sync-workspace-deployment.yaml  \
+      --show-only templates/sync-workspace-deployment.yaml  \
       --set 'syncWorkspace.enabled=true' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.volumes[1].secret.secretName | contains("workspacesecrets")' | tee /dev/stderr)
@@ -152,7 +152,7 @@ load _helpers
 @test "syncWorkspace/Deployment: workspace secrets variables can be overridden" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/sync-workspace-deployment.yaml  \
+      --show-only templates/sync-workspace-deployment.yaml  \
       --set 'syncWorkspace.enabled=true' \
       --set 'syncWorkspace.sensitiveVariables.secretName=newsecrets' \
       . | tee /dev/stderr |

--- a/test/unit/sync-workspace-role.bats
+++ b/test/unit/sync-workspace-role.bats
@@ -5,7 +5,7 @@ load _helpers
 @test "syncWorkspace/Role: enabled by default" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/sync-workspace-role.yaml  \
+      --show-only templates/sync-workspace-role.yaml  \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
@@ -14,27 +14,27 @@ load _helpers
 @test "syncWorkspace/Role: disabled with global.enabled=false" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/sync-workspace-role.yaml  \
+      --show-only templates/sync-workspace-role.yaml 
       --set 'global.enabled=false' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
+  [ "${actual}" = "" ]
 }
 
 @test "syncWorkspace/Role: disabled with sync disabled" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/sync-workspace-role.yaml  \
+      --show-only templates/sync-workspace-role.yaml  
       --set 'syncWorkspace.enabled=false' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
+  [ "${actual}" = "" ]
 }
 
 @test "syncWorkspace/Role: enabled with sync enabled" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/sync-workspace-role.yaml  \
+      --show-only templates/sync-workspace-role.yaml  \
       --set 'syncWorkspace.enabled=true' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
@@ -44,7 +44,7 @@ load _helpers
 @test "syncWorkspace/Role: enabled with sync enabled and global.enabled=false" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/sync-workspace-role.yaml  \
+      --show-only templates/sync-workspace-role.yaml  \
       --set 'global.enabled=false' \
       --set 'syncWorkspace.enabled=true' \
       . | tee /dev/stderr |

--- a/test/unit/sync-workspace-role.bats
+++ b/test/unit/sync-workspace-role.bats
@@ -2,13 +2,13 @@
 
 load _helpers
 
-@test "syncWorkspace/Role: disabled by default" {
+@test "syncWorkspace/Role: enabled by default" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/sync-workspace-role.yaml  \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
+  [ "${actual}" = "true" ]
 }
 
 @test "syncWorkspace/Role: disabled with global.enabled=false" {

--- a/test/unit/sync-workspace-rolebinding.bats
+++ b/test/unit/sync-workspace-rolebinding.bats
@@ -5,7 +5,7 @@ load _helpers
 @test "syncWorkspace/RoleBinding: enabled by default" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/sync-workspace-rolebinding.yaml  \
+      --show-only templates/sync-workspace-rolebinding.yaml  \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
@@ -14,27 +14,27 @@ load _helpers
 @test "syncWorkspace/RoleBinding: disabled with global.enabled=false" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/sync-workspace-rolebinding.yaml  \
+      --show-only templates/sync-workspace-rolebinding.yaml  \
       --set 'global.enabled=false' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
+  [ "${actual}" = "" ]
 }
 
 @test "syncWorkspace/RoleBinding: disabled with sync disabled" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/sync-workspace-rolebinding.yaml  \
+      --show-only templates/sync-workspace-rolebinding.yaml  \
       --set 'syncWorkspace.enabled=false' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
+  [ "${actual}" = "" ]
 }
 
 @test "syncWorkspace/RoleBinding: enabled with sync enabled" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/sync-workspace-rolebinding.yaml  \
+      --show-only templates/sync-workspace-rolebinding.yaml  \
       --set 'syncWorkspace.enabled=true' \
       . | tee /dev/stderr |
       yq -s 'length > 0' | tee /dev/stderr)
@@ -44,7 +44,7 @@ load _helpers
 @test "syncWorkspace/RoleBinding: enabled with sync enabled and global.enabled=false" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/sync-workspace-rolebinding.yaml  \
+      --show-only templates/sync-workspace-rolebinding.yaml  \
       --set 'global.enabled=false' \
       --set 'syncWorkspace.enabled=true' \
       . | tee /dev/stderr |

--- a/test/unit/sync-workspace-rolebinding.bats
+++ b/test/unit/sync-workspace-rolebinding.bats
@@ -2,13 +2,13 @@
 
 load _helpers
 
-@test "syncWorkspace/RoleBinding: disabled by default" {
+@test "syncWorkspace/RoleBinding: enabled by default" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/sync-workspace-rolebinding.yaml  \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
+  [ "${actual}" = "true" ]
 }
 
 @test "syncWorkspace/RoleBinding: disabled with global.enabled=false" {

--- a/test/unit/sync-workspace-serviceaccount.bats
+++ b/test/unit/sync-workspace-serviceaccount.bats
@@ -5,7 +5,7 @@ load _helpers
 @test "syncWorkspace/ServiceAccount: enabled by default" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/sync-workspace-serviceaccount.yaml  \
+      --show-only templates/sync-workspace-serviceaccount.yaml  \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
@@ -14,27 +14,27 @@ load _helpers
 @test "syncWorkspace/ServiceAccount: disabled with global.enabled=false" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/sync-workspace-serviceaccount.yaml  \
+      --show-only templates/sync-workspace-serviceaccount.yaml  \
       --set 'global.enabled=false' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
+  [ "${actual}" = "" ]
 }
 
 @test "syncWorkspace/ServiceAccount: disabled with sync disabled" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/sync-workspace-serviceaccount.yaml  \
+      --show-only templates/sync-workspace-serviceaccount.yaml  \
       --set 'syncWorkspace.enabled=false' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
+  [ "${actual}" = "" ]
 }
 
 @test "syncWorkspace/ServiceAccount: enabled with sync enabled" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/sync-workspace-serviceaccount.yaml  \
+      --show-only templates/sync-workspace-serviceaccount.yaml  \
       --set 'syncWorkspace.enabled=true' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
@@ -44,7 +44,7 @@ load _helpers
 @test "syncWorkspace/ServiceAccount: enabled with sync enabled and global.enabled=false" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/sync-workspace-serviceaccount.yaml  \
+      --show-only templates/sync-workspace-serviceaccount.yaml  \
       --set 'global.enabled=false' \
       --set 'syncWorkspace.enabled=true' \
       . | tee /dev/stderr |

--- a/test/unit/sync-workspace-serviceaccount.bats
+++ b/test/unit/sync-workspace-serviceaccount.bats
@@ -2,13 +2,13 @@
 
 load _helpers
 
-@test "syncWorkspace/ServiceAccount: disabled by default" {
+@test "syncWorkspace/ServiceAccount: enabled by default" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/sync-workspace-serviceaccount.yaml  \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
+  [ "${actual}" = "true" ]
 }
 
 @test "syncWorkspace/ServiceAccount: disabled with global.enabled=false" {

--- a/test/unit/test-runner.bats
+++ b/test/unit/test-runner.bats
@@ -5,7 +5,7 @@ load _helpers
 @test "testRunner/Pod: enabled by default" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/tests/test-runner.yaml  \
+      --show-only templates/tests/test-runner.yaml  \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
@@ -14,9 +14,9 @@ load _helpers
 @test "testRunner/Pod: disabled when tests.enabled=false" {
   cd `chart_dir`
   local actual=$(helm template \
-      -x templates/tests/test-runner.yaml  \
+      --show-only templates/tests/test-runner.yaml  \
       --set 'tests.enabled=false' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
+  [ "${actual}" = "" ]
 }


### PR DESCRIPTION
Fixes unit tests for Helm v3.

```shell
$ bats ./test/unit                                                                                                                                                                                    
 ✓ syncWorkspace/Deployment: enabled by default
 ✓ syncWorkspace/Deployment: enable with global.enabled false
 ✓ syncWorkspace/Deployment: disable with syncWorkspace.enabled
 ✓ syncWorkspace/Deployment: disable with global.enabled
 ✓ syncWorkspace/Deployment: image defaults to global.imageK8S
 ✓ syncWorkspace/Deployment: image can be overridden with syncWorkspace.image
 ✓ syncWorkspace/Deployment: watch namespace defaults to release namespace
 ✓ syncWorkspace/Deployment: watch namespace can be overridden
 ✓ syncWorkspace/Deployment: serviceAccount set when sync enabled
 ✓ syncWorkspace/Deployment: add terraformrc secrets name
 ✓ syncWorkspace/Deployment: add terraformrc secrets key
 ✓ syncWorkspace/Deployment: terraformrc secrets variables can be overridden
 ✓ syncWorkspace/Deployment: add workspace secrets variables
 ✓ syncWorkspace/Deployment: workspace secrets variables can be overridden
 ✓ syncWorkspace/Role: enabled by default
 ✓ syncWorkspace/Role: disabled with global.enabled=false
 ✓ syncWorkspace/Role: disabled with sync disabled
 ✓ syncWorkspace/Role: enabled with sync enabled
 ✓ syncWorkspace/Role: enabled with sync enabled and global.enabled=false
 ✓ syncWorkspace/RoleBinding: enabled by default
 ✓ syncWorkspace/RoleBinding: disabled with global.enabled=false
 ✓ syncWorkspace/RoleBinding: disabled with sync disabled
 ✓ syncWorkspace/RoleBinding: enabled with sync enabled
 ✓ syncWorkspace/RoleBinding: enabled with sync enabled and global.enabled=false
 ✓ syncWorkspace/ServiceAccount: enabled by default
 ✓ syncWorkspace/ServiceAccount: disabled with global.enabled=false
 ✓ syncWorkspace/ServiceAccount: disabled with sync disabled
 ✓ syncWorkspace/ServiceAccount: enabled with sync enabled
 ✓ syncWorkspace/ServiceAccount: enabled with sync enabled and global.enabled=false
 ✓ testRunner/Pod: enabled by default
 ✓ testRunner/Pod: disabled when tests.enabled=false

31 tests, 0 failures
```