### PR TITLE
Ci/add helm charts trigger

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,9 +8,31 @@ jobs:
       - run:
           name: Run Unit Tests
           command: bats ./test/unit
+  update-helm-charts-index:
+    docker:
+      - image: circleci/golang:latest
+    steps:
+      - run:
+          name: update helm-charts index
+          command: |
+            curl --show-error --silent --fail --user "${CIRCLE_TOKEN}:" \
+                -X POST \
+                -H 'Content-Type: application/json' \
+                -H 'Accept: application/json' \
+                -d "{\"branch\": \"master\",\"parameters\":{\"SOURCE_REPO\": \"${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}\",\"SOURCE_TAG\": \"${CIRCLE_TAG}\"}}" \
+                "${CIRCLE_ENDPOINT}/${CIRCLE_PROJECT}/pipeline"
 
 workflows:
   version: 2
   test:
     jobs:
       - unit
+  update-helm-charts-index:
+    jobs:
+      - update-helm-charts-index:
+          context: helm-charts-trigger
+          filters:
+            tags:
+              only: /^v.*/ # only triggers updating of the helm index on tags
+            branches:
+              ignore: /.*/ # don't trigger helm index update on any branch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,16 @@
+version: 2
+jobs:
+  unit:
+    docker:
+      - image: hashicorpdev/terraform-helm-test:0.1.0
+    steps:
+      - checkout
+      - run:
+          name: Run Unit Tests
+          command: bats ./test/unit
+
+workflows:
+  version: 2
+  test:
+    jobs:
+      - unit

--- a/test/docker/Test.dockerfile
+++ b/test/docker/Test.dockerfile
@@ -6,11 +6,11 @@
 # a script to configure kubectl, potentially install Helm, and run the tests
 # manually. This image only has the dependencies pre-installed.
 
-FROM alpine:latest
+FROM alpine/helm:3.2.0
 WORKDIR /root
 
 ENV BATS_VERSION "1.1.0"
-ENV TERRAFORM_VERSION "0.12.10"
+ENV TERRAFORM_VERSION "0.12.24"
 
 # base packages
 RUN apk update && apk add --no-cache --virtual .build-deps \
@@ -25,7 +25,7 @@ RUN apk update && apk add --no-cache --virtual .build-deps \
     jq
 
 # yq
-RUN pip install yq
+RUN pip install --no-cache-dir yq
 
 # gcloud
 RUN curl -OL https://dl.google.com/dl/cloudsdk/channels/rapid/install_google_cloud_sdk.bash && \
@@ -35,17 +35,16 @@ RUN curl -OL https://dl.google.com/dl/cloudsdk/channels/rapid/install_google_clo
 # terraform
 RUN curl -sSL https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip -o /tmp/tf.zip \
     && unzip /tmp/tf.zip  \
-    && ln -s /root/terraform /usr/local/bin/terraform
+    && ln -s /root/terraform /usr/local/bin/terraform \
+    && rm /tmp/tf.zip
 
 # kubectl
 RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && \
     chmod +x ./kubectl && \
     mv ./kubectl /usr/local/bin/kubectl
 
-# helm
-RUN curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
-
 # bats
 RUN curl -sSL https://github.com/bats-core/bats-core/archive/v${BATS_VERSION}.tar.gz -o /tmp/bats.tgz \
     && tar -zxf /tmp/bats.tgz -C /tmp \
-    && /bin/bash /tmp/bats-core-${BATS_VERSION}/install.sh /usr/local
+    && /bin/bash /tmp/bats-core-${BATS_VERSION}/install.sh /usr/local \
+    && rm -rf /tmp/bats*


### PR DESCRIPTION
This PR moves the test docker image to using helm3, updates Terraform, and cleans up temp files used during various CLI tool installations. The image is built manually and pushed up to `hashicorpdev/terraform-helm-test:0.1.0`. I don't anticipate it changing very much but if it does, we can automate it. 

It also adds unit tests into CircleCI and an API trigger to rebuild the helm charts index on every tagged release. 