### PR TITLE
Update to Terraform 0.12.25, add TF_VERSION environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.1.4-alpha (May 14, 2020)
 
 * Update Helm chart to pass TF_VERSION override
 * Update terraform-k8s to v0.1.4-alpha
@@ -10,7 +10,6 @@
 ## 0.1.2-alpha
 
 * Update terraform-k8s to v0.1.2-alpha
-
 
 ## 0.1.0-alpha
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+* Update Helm chart to pass TF_VERSION override
+* Update terraform-k8s to v0.1.4-alpha
+
 ## 0.1.3-alpha
 
 * Update terraform-k8s to v0.1.3-alpha

--- a/docs/workspace-sync.html.md
+++ b/docs/workspace-sync.html.md
@@ -109,6 +109,15 @@ control to these secrets must be enforced by [Kubernetes Role-Based Access
 Control (RBAC)](https://kubernetes.io/docs/reference/access-authn-authz/rbac/)
 policies.
 
+### Terraform Version
+
+By default, the Operator will create a Terraform Cloud/Enterprise workspace with
+[a pinned version](https://github.com/hashicorp/terraform-k8s/blob/master/operator/version/version.go)
+of Terraform.
+
+Override the Terraform version that will be set for the workspace by changing the
+Helm value `syncWorkspace.terraformVersion` to the Terraform version of choice.
+
 ## Deploy the Operator
 
 Use the [Helm chart](https://github.com/hashicorp/terraform-helm) repository to

--- a/templates/sync-workspace-deployment.yaml
+++ b/templates/sync-workspace-deployment.yaml
@@ -30,6 +30,7 @@ spec:
       containers:
         - name: terraform-sync-workspace
           image: "{{ default .Values.global.imageK8S .Values.syncWorkspace.image }}"
+          imagePullPolicy: "{{ default "IfNotPresent" .Values.syncWorkspace.imagePullPolicy }}"
           env:
             - name: POD_NAME
               valueFrom:
@@ -37,6 +38,10 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "terraform-k8s"
+            {{- if .Values.syncWorkspace.terraformVersion }}
+            - name: TF_VERSION
+              value: "{{ .Values.syncWorkspace.terraformVersion }}"
+            {{- end }}
             - name: TF_CLI_CONFIG_FILE
               value: "/etc/terraform/.terraformrc"
           volumeMounts:

--- a/templates/tests/test-runner.yaml
+++ b/templates/tests/test-runner.yaml
@@ -16,6 +16,7 @@ spec:
   containers:
     - name: terraform-test
       image: "{{ .Values.global.imageK8S }}"
+      imagePullPolicy: "{{ default "IfNotPresent" .Values.syncWorkspace.imagePullPolicy }}"
       env:
         - name: HOST_IP
           valueFrom:

--- a/test/unit/sync-workspace-deployment.bats
+++ b/test/unit/sync-workspace-deployment.bats
@@ -93,6 +93,30 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
+# terraform version
+
+@test "syncWorkspace/Deployment: terraform version defaults to operator-compiled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/sync-workspace-deployment.yaml  \
+      --set 'syncWorkspace.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].env | any(contains("TF_VERSION"))' | tee /dev/stderr)
+  [ "${actual}" = "" ]
+}
+
+@test "syncWorkspace/Deployment: terraform version is TF_VERSION" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/sync-workspace-deployment.yaml  \
+      --set 'syncWorkspace.enabled=true' \
+      --set 'syncWorkspace.terraformVersion=0.11.1' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].env[2].value == "0.11.1"' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+#--------------------------------------------------------------------
 # serviceAccount
 
 @test "syncWorkspace/Deployment: serviceAccount set when sync enabled" {

--- a/values.dev.yaml
+++ b/values.dev.yaml
@@ -1,0 +1,9 @@
+# Parameters used for testing operator in development
+# run with `helm install -f values.yml -f values.dev.yaml .`
+
+global:
+  imageK8S: "terraform-k8s-dev:latest"
+  imagePullPolicy: "Never"
+
+syncWorkspace:
+  terraformVersion: 0.12.24

--- a/values.dev.yaml
+++ b/values.dev.yaml
@@ -6,4 +6,4 @@ global:
   imagePullPolicy: "Never"
 
 syncWorkspace:
-  terraformVersion: 0.12.24
+  terraformVersion: 0.12.25

--- a/values.yaml
+++ b/values.yaml
@@ -30,6 +30,11 @@ syncWorkspace:
   # to the release namespace
   k8WatchNamespace: null
 
+  # terraformVersion describes the version of Terraform to use for each workspace.
+  # If this is not set then it will default to the latest version of Terraform
+  # compiled with the operator.
+  terraformVersion: null
+
   # Log verbosity level. One of "trace", "debug", "info", "warn", or "error".
   # Defaults to "info".
   logLevel: null

--- a/values.yaml
+++ b/values.yaml
@@ -11,7 +11,7 @@ global:
   # imageK8S is the name (and tag) of the terraform-k8s Docker image that
   # is used for functionality such as workspace sync. This can be overridden
   # per component.
-  imageK8S: "hashicorp/terraform-k8s:0.1.3-alpha"
+  imageK8S: "hashicorp/terraform-k8s:0.1.4-alpha"
 
 # syncWorkspace will run the workspace sync process to sync K8S Workspaces with
 # Terraform Cloud workspaces.


### PR DESCRIPTION
Relates hashicorp/terraform-k8s/issues/47.

Add TF_VERSION override to Helm chart, which specifies the version of Terraform to use in the workspace. Defaults to operator's default Terraform version if not specified.