### PR TITLE
Update chart installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,43 @@ Before installing the chart, you must create two Kubernetes secrets:
    $ kubectl -n $NAMESPACE create secret generic workspacesecrets --from-literal=secret_key=abc123
    ```
 
-For now, we do not host a chart repository. To use the charts, you must
-download this repository and unpack it into a directory.
+ To use the charts, you must
+add the HashiCorp Helm Chart repository. You'll need to use the --devel flag for most helm commands since the chart is in alpha.
+
+```shell
+$ helm repo add hashicorp https://helm.releases.hashicorp.com
+$ helm search repo hashicorp/terraform --devel
+```
+```
+NAME               	CHART VERSION	APP VERSION	DESCRIPTION
+hashicorp/terraform	0.1.3-alpha  	           	Install and configure Terraform Cloud Operator ...
+```
 Assuming this repository was unpacked into the directory `terraform-helm`, the chart can
 then be installed directly:
+```shell
+$ helm install --devel --namespace ${RELEASE_NAMESPACE} hashicorp/terraform --generate-name
+```
+```
+NAME: terraform-1589480669
+LAST DEPLOYED: Thu May 14 11:24:32 2020
+NAMESPACE: operator
+STATUS: deployed
+REVISION: 1
+NOTES:
+Thank you for installing HashiCorp Terraform Cloud Operator!
 
-    helm install -n ${RELEASE_NAMESPACE} ${RELEASE_NAME} ./terraform-helm
+Now that you have deployed HashiCorp Terraform Cloud Operator, you should look over the docs on using
+Terraform with Kubernetes available here:
+
+https://github.com/hashicorp/terraform-k8s/blob/master/README.md
+
+
+Your release is named terraform-1589480669. To learn more about the release, try:
+
+  $ helm status terraform-1589480669
+  $ helm get terraform-1589480669
+```
+    
 
 Please see the many options supported in the `values.yaml`
 file.
@@ -64,7 +95,8 @@ behind.
 Note that the Helm chart automatically installs all Custom Resource Definitions under
 the `crds/` directory. As a result, any updates to the schema must be manually copied into
 the directory and removed from the Kubernetes cluster:
-
-    kubectl delete crd workspaces.app.terraform.io
+```shell
+$ kubectl delete crd workspaces.app.terraform.io
+```
 
 If the CRD is not updated correctly, you will not be able to create a Workspace Custom Resource.


### PR DESCRIPTION
Update chart installation instructions to use the HashiCorp helm repo in the same way Vault and Consult documentation does.