### PR TITLE
check that git tag == chart tag on tagged releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,16 @@ jobs:
       - image: circleci/golang:latest
     steps:
       - run:
+          name: verify Chart version matches tag version
+          command: |
+            GO111MODULE=on go get github.com/mikefarah/yq/v2
+            git_tag=$(echo "${CIRCLE_TAG#v}")
+            chart_tag=$(yq r Chart.yaml version)
+            if [ "${git_tag}" != "${chart_tag}" ]; then
+              echo "chart version (${chart_tag}) did not match git version (${git_tag})"
+              exit 1
+            fi
+      - run:
           name: update helm-charts index
           command: |
             curl --show-error --silent --fail --user "${CIRCLE_TOKEN}:" \


### PR DESCRIPTION
It is easy to miss updating the version number in Chart.yaml when tagging a release so this is a sanity check to make sure the git tag version matches the version in the Chart.yaml file. 