### PR TITLE
fix checkout and add slack notifications for tag build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,7 @@
-version: 2
+version: 2.1
+orbs:
+  slack: circleci/slack@3.4.2
+
 jobs:
   unit:
     docker:
@@ -32,6 +35,9 @@ jobs:
                 -H 'Accept: application/json' \
                 -d "{\"branch\": \"master\",\"parameters\":{\"SOURCE_REPO\": \"${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}\",\"SOURCE_TAG\": \"${CIRCLE_TAG}\"}}" \
                 "${CIRCLE_ENDPOINT}/${CIRCLE_PROJECT}/pipeline"
+      - slack/status:
+          fail_only: true
+          failure_message: "Failed to trigger an update to the helm charts index. Check the logs at: ${CIRCLE_BUILD_URL}"
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ jobs:
     docker:
       - image: circleci/golang:latest
     steps:
+      - checkout
       - run:
           name: verify Chart version matches tag version
           command: |


### PR DESCRIPTION
In #14 I didn't notice that the code was not actually checked out so there was no Chart.yaml file to check. I have also added a slack notification to send something when there is a failure in the tagged build workflow. 