### PR TITLE
Support private CAs

### DIFF
--- a/templates/sync-workspace-deployment.yaml
+++ b/templates/sync-workspace-deployment.yaml
@@ -47,6 +47,11 @@ spec:
             - name: TF_URL
               value: "{{ default "" .Values.syncWorkspace.tfeAddress }}"
           volumeMounts:
+          {{- if .Values.useCustomCA }}
+          - name: cacert
+            mountPath: "/etc/ssl/certs/"
+            readOnly: true
+          {{- end }}
           - name: terraformrc
             mountPath: "/etc/terraform"
             readOnly: true
@@ -83,6 +88,14 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
       volumes:
+        {{- if .Values.useCustomCA }}
+        - name: cacert
+          secret:
+            secretName: cacert
+            items:
+              - key: ca_file
+                path: "ca-certificates.crt"
+        {{- end }}
         - name: terraformrc
           secret:
             secretName: {{ required "secret name for terraformrc file required" .Values.syncWorkspace.terraformRC.secretName }}

--- a/templates/sync-workspace-deployment.yaml
+++ b/templates/sync-workspace-deployment.yaml
@@ -47,7 +47,7 @@ spec:
             - name: TF_URL
               value: "{{ default "" .Values.syncWorkspace.tfeAddress }}"
           volumeMounts:
-          {{- if .Values.useCustomCA }}
+          {{- if .Values.CACerts}}
           - name: cacert
             mountPath: "/etc/ssl/certs/"
             readOnly: true
@@ -88,7 +88,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
       volumes:
-        {{- if .Values.useCustomCA }}
+        {{- if .Values.CACerts}}
         - name: cacert
           secret:
             secretName: cacert

--- a/templates/sync-workspace-secret.yaml
+++ b/templates/sync-workspace-secret.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.CACerts }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cacert
+type: Opaque
+data:
+  ca_file: |-
+    {{ required "CACerts value needs to be set" .Values.CACerts| b64enc | indent 2 }}
+{{- end }}

--- a/templates/sync-workspace-secret.yaml
+++ b/templates/sync-workspace-secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: cacert
+  namespace: {{ .Release.Namespace }}
 type: Opaque
 data:
   ca_file: |-

--- a/values.yaml
+++ b/values.yaml
@@ -62,8 +62,10 @@ tests:
   # moduleSource defaults to this repository.
   # moduleSource: git::https://github.com/hashicorp/terraform-helm.git//test/module
 
-# Set useCustomCA to true if the TFE instance the operator talks to is using
-# a private CA. When this is set to true you should also create a secret called
-# cacert that contains a key named ca_file and contains all the CA certificates
-# the operator needs in PEM format.
-useCustomCA: false
+# If the TFE instance the operator talks to is using a private CA then CACerts
+# can be used to install a custom CA bundle in the operator's container that 
+# will allow it to communicate with TFE.
+#
+# CACerts can be set like this:
+# helm install <other parameters> --set-file CACerts=/path/to/certs.pem
+CACerts: ""

--- a/values.yaml
+++ b/values.yaml
@@ -61,3 +61,9 @@ tests:
   organization: tf-operator
   # moduleSource defaults to this repository.
   # moduleSource: git::https://github.com/hashicorp/terraform-helm.git//test/module
+
+# Set useCustomCA to true if the TFE instance the operator talks to is using
+# a private CA. When this is set to true you should also create a secret called
+# cacert that contains a key named ca_file and contains all the CA certificates
+# the operator needs in PEM format.
+useCustomCA: false


### PR DESCRIPTION
Add an extra option to indicate the operator should be using the
supplied CA certificate bundle instead of the default one.

This is useful for cases where the operator needs to talk to TFE
instances that use certificates signed by private CAs.

Closes hashicorp/terraform-k8s#60 