### PR TITLE
Use docker mirror

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 jobs:
   unit:
     docker:
-      - image: hashicorpdev/terraform-helm-test:0.1.0
+      - image: docker.mirror.hashicorp.services/hashicorpdev/terraform-helm-test:0.1.0
     steps:
       - checkout
       - run:
@@ -13,7 +13,7 @@ jobs:
           command: bats ./test/unit
   update-helm-charts-index:
     docker:
-      - image: circleci/golang:latest
+      - image: docker.mirror.hashicorp.services/circleci/golang:latest
     steps:
       - checkout
       - run:

--- a/test/docker/Test.dockerfile
+++ b/test/docker/Test.dockerfile
@@ -6,7 +6,7 @@
 # a script to configure kubectl, potentially install Helm, and run the tests
 # manually. This image only has the dependencies pre-installed.
 
-FROM alpine/helm:3.2.0
+FROM docker.mirror.hashicorp.services/alpine/helm:3.2.0
 WORKDIR /root
 
 ENV BATS_VERSION "1.1.0"


### PR DESCRIPTION
CHANGELOG: no impact

Dockerhub is going to rate limit unauthenticated pulls on November 1st. IPs from CI machines (with the exception of github acitons) will be near their limit all the time. We're moving projects to use a public un-rate-limited Mirror of these images instead. Let me know if you have any q's, otherwise feel free to merge when you can! 
