### PR TITLE
Post operator-sdk upgrade changes

### DIFF
--- a/crds/app.terraform.io_workspaces_crd.yaml
+++ b/crds/app.terraform.io_workspaces_crd.yaml
@@ -1,6 +1,11 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
+  creationTimestamp: null
   name: workspaces.app.terraform.io
 spec:
   group: app.terraform.io
@@ -146,9 +151,13 @@ spec:
                               for env vars'
                             type: string
                           divisor:
+                            anyOf:
+                            - type: integer
+                            - type: string
                             description: Specifies the output format of the exposed
                               resources, defaults to "1"
-                            type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
                           resource:
                             description: 'Required: resource to select'
                             type: string
@@ -247,3 +256,9 @@ spec:
   - name: v1alpha1
     served: true
     storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/templates/sync-workspace-deployment.yaml
+++ b/templates/sync-workspace-deployment.yaml
@@ -66,7 +66,7 @@ spec:
             - /bin/terraform-k8s
           args:
             - --enable-leader-election
-            - --k8s-watch-namespace={{ default .Release.Namespace .Values.syncWorkspace.k8WatchNamespace}}
+            - --k8s-watch-namespace="{{ default .Release.Namespace .Values.syncWorkspace.k8WatchNamespace}}"
           livenessProbe:
             httpGet:
               path: /metrics

--- a/templates/sync-workspace-deployment.yaml
+++ b/templates/sync-workspace-deployment.yaml
@@ -63,14 +63,10 @@ spec:
             mountPath: "/tmp/secrets"
             readOnly: true
           command:
-            - "/bin/sh"
-            - "-ec"
-            - |
-              terraform-k8s sync-workspace \
-                --k8s-watch-namespace="{{ default .Release.Namespace .Values.syncWorkspace.k8WatchNamespace}}" \
-                {{- if .Values.syncWorkspace.logLevel }}
-                --zap-level={{ .Values.syncWorkspace.logLevel }} \
-                {{- end }}
+            - /bin/terraform-k8s
+          args:
+            - --enable-leader-election
+            - --k8s-watch-namespace={{ default .Release.Namespace .Values.syncWorkspace.k8WatchNamespace}}
           livenessProbe:
             httpGet:
               path: /metrics

--- a/templates/sync-workspace-role.yaml
+++ b/templates/sync-workspace-role.yaml
@@ -24,6 +24,14 @@ rules:
   verbs:
   - '*'
 - apiGroups:
+  - ""
+  resources:
+  - configmaps/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
   - apps
   resources:
   - deployments

--- a/test/unit/sync-workspace-deployment.bats
+++ b/test/unit/sync-workspace-deployment.bats
@@ -127,7 +127,7 @@ load _helpers
       --show-only templates/sync-workspace-deployment.yaml  \
       --set 'syncWorkspace.enabled=true' \
       . | tee /dev/stderr |
-      yq -r '.spec.template.spec.containers[0].command | any(contains("--k8s-watch-namespace=\"default\""))' | tee /dev/stderr)
+      yq -r '.spec.template.spec.containers[0].args | any(contains("--k8s-watch-namespace=\"default\""))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 
@@ -138,7 +138,7 @@ load _helpers
       --set 'syncWorkspace.enabled=true' \
       --set 'syncWorkspace.k8WatchNamespace=dev' \
       . | tee /dev/stderr |
-      yq -r '.spec.template.spec.containers[0].command | any(contains("-k8s-watch-namespace=\"dev\""))' | tee /dev/stderr)
+      yq -r '.spec.template.spec.containers[0].args | any(contains("-k8s-watch-namespace=\"dev\""))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 


### PR DESCRIPTION
Following the operator's upgrade to operator SDK 1.2 we need to make
some change to this chart.

Some of the changes here break the chart's compatibility with previous
versions. We will be upgrading the templates with the necessary image
tag right before the next release.
