### PR TITLE
Fixes RBAC error when using k8WatchNamespace helm value

### DIFF
--- a/templates/sync-workspace-role.yaml
+++ b/templates/sync-workspace-role.yaml
@@ -1,7 +1,11 @@
 {{- $syncEnabled := (or (and (ne (.Values.syncWorkspace.enabled | toString) "-") .Values.syncWorkspace.enabled) (and (eq (.Values.syncWorkspace.enabled | toString) "-") .Values.global.enabled)) }}
 {{- if $syncEnabled }}
 apiVersion: rbac.authorization.k8s.io/v1
+{{- if .Values.syncWorkspace.k8WatchNamespace }}
+kind: ClusterRole
+{{- else }}
 kind: Role
+{{- end }}
 metadata:
   name: {{ template "terraform.fullname" . }}-sync-workspace
   labels:

--- a/templates/sync-workspace-role.yaml
+++ b/templates/sync-workspace-role.yaml
@@ -1,11 +1,7 @@
 {{- $syncEnabled := (or (and (ne (.Values.syncWorkspace.enabled | toString) "-") .Values.syncWorkspace.enabled) (and (eq (.Values.syncWorkspace.enabled | toString) "-") .Values.global.enabled)) }}
 {{- if $syncEnabled }}
 apiVersion: rbac.authorization.k8s.io/v1
-{{- if .Values.syncWorkspace.k8WatchNamespace }}
-kind: ClusterRole
-{{- else }}
-kind: Role
-{{- end }}
+kind: {{ ternary "Role" "ClusterRole" (empty .Values.syncWorkspace.k8WatchNamespace) }}
 metadata:
   name: {{ template "terraform.fullname" . }}-sync-workspace
   labels:

--- a/templates/sync-workspace-role.yaml
+++ b/templates/sync-workspace-role.yaml
@@ -1,7 +1,8 @@
 {{- $syncEnabled := (or (and (ne (.Values.syncWorkspace.enabled | toString) "-") .Values.syncWorkspace.enabled) (and (eq (.Values.syncWorkspace.enabled | toString) "-") .Values.global.enabled)) }}
 {{- if $syncEnabled }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: {{ ternary "Role" "ClusterRole" (empty .Values.syncWorkspace.k8WatchNamespace) }}
+{{- $kind := (ternary "Role" "ClusterRole" (or (empty .Values.syncWorkspace.k8WatchNamespace) (eq (.Values.syncWorkspace.k8WatchNamespace | toString) .Release.Namespace))) }}
+kind: {{ $kind }}
 metadata:
   name: {{ template "terraform.fullname" . }}-sync-workspace
   labels:

--- a/templates/sync-workspace-rolebinding.yaml
+++ b/templates/sync-workspace-rolebinding.yaml
@@ -1,7 +1,8 @@
 {{- $syncEnabled := (or (and (ne (.Values.syncWorkspace.enabled | toString) "-") .Values.syncWorkspace.enabled) (and (eq (.Values.syncWorkspace.enabled | toString) "-") .Values.global.enabled)) }}
 {{- if $syncEnabled }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: {{ ternary "RoleBinding" "ClusterRoleBinding" (empty .Values.syncWorkspace.k8WatchNamespace) }}
+{{- $kind := (ternary "Role" "ClusterRole" (or (empty .Values.syncWorkspace.k8WatchNamespace) (eq (.Values.syncWorkspace.k8WatchNamespace | toString) .Release.Namespace))) }}
+kind: {{ ternary "RoleBinding" "ClusterRoleBinding" (eq $kind "Role") }}
 metadata:
   name: {{ template "terraform.fullname" . }}-sync-workspace
   labels:
@@ -14,7 +15,7 @@ subjects:
   name: {{ template "terraform.fullname" . }}-sync-workspace
   namespace: {{ .Release.Namespace }}
 roleRef:
-  kind: {{ ternary "Role" "ClusterRole" (empty .Values.syncWorkspace.k8WatchNamespace) }}
+  kind: {{ $kind }}
   name: {{ template "terraform.fullname" . }}-sync-workspace
   apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/templates/sync-workspace-rolebinding.yaml
+++ b/templates/sync-workspace-rolebinding.yaml
@@ -1,11 +1,7 @@
 {{- $syncEnabled := (or (and (ne (.Values.syncWorkspace.enabled | toString) "-") .Values.syncWorkspace.enabled) (and (eq (.Values.syncWorkspace.enabled | toString) "-") .Values.global.enabled)) }}
 {{- if $syncEnabled }}
 apiVersion: rbac.authorization.k8s.io/v1
-{{- if .Values.syncWorkspace.k8WatchNamespace }}
-kind: ClusterRoleBinding
-{{- else }}
-kind: RoleBinding
-{{- end }}
+kind: {{ ternary "RoleBinding" "ClusterRoleBinding" (empty .Values.syncWorkspace.k8WatchNamespace) }}
 metadata:
   name: {{ template "terraform.fullname" . }}-sync-workspace
   labels:
@@ -18,11 +14,7 @@ subjects:
   name: {{ template "terraform.fullname" . }}-sync-workspace
   namespace: {{ .Release.Namespace }}
 roleRef:
-  {{- if .Values.syncWorkspace.k8WatchNamespace }}
-  kind: ClusterRole
-  {{- else }}
-  kind: Role
-  {{- end }}
+  kind: {{ ternary "Role" "ClusterRole" (empty .Values.syncWorkspace.k8WatchNamespace) }}
   name: {{ template "terraform.fullname" . }}-sync-workspace
   apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/templates/sync-workspace-rolebinding.yaml
+++ b/templates/sync-workspace-rolebinding.yaml
@@ -1,7 +1,11 @@
 {{- $syncEnabled := (or (and (ne (.Values.syncWorkspace.enabled | toString) "-") .Values.syncWorkspace.enabled) (and (eq (.Values.syncWorkspace.enabled | toString) "-") .Values.global.enabled)) }}
 {{- if $syncEnabled }}
 apiVersion: rbac.authorization.k8s.io/v1
+{{- if .Values.syncWorkspace.k8WatchNamespace }}
+kind: ClusterRoleBinding
+{{- else }}
 kind: RoleBinding
+{{- end }}
 metadata:
   name: {{ template "terraform.fullname" . }}-sync-workspace
   labels:
@@ -12,8 +16,13 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: {{ template "terraform.fullname" . }}-sync-workspace
+  namespace: {{ .Release.Namespace }}
 roleRef:
+  {{- if .Values.syncWorkspace.k8WatchNamespace }}
+  kind: ClusterRole
+  {{- else }}
   kind: Role
+  {{- end }}
   name: {{ template "terraform.fullname" . }}-sync-workspace
   apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -11,7 +11,7 @@ global:
   # imageK8S is the name (and tag) of the terraform-k8s Docker image that
   # is used for functionality such as workspace sync. This can be overridden
   # per component.
-  imageK8S: "terraform-k8s-dev:latest"
+  imageK8S: "hashicorp/terraform-k8s:1.0.0"
 
 # syncWorkspace will run the workspace sync process to sync K8S Workspaces with
 # Terraform Cloud workspaces.

--- a/values.yaml
+++ b/values.yaml
@@ -11,7 +11,7 @@ global:
   # imageK8S is the name (and tag) of the terraform-k8s Docker image that
   # is used for functionality such as workspace sync. This can be overridden
   # per component.
-  imageK8S: "hashicorp/terraform-k8s:1.0.0"
+  imageK8S: "terraform-k8s-dev:latest"
 
 # syncWorkspace will run the workspace sync process to sync K8S Workspaces with
 # Terraform Cloud workspaces.


### PR DESCRIPTION
If helm value k8WatchNamespace is different from release namespace, operator will now use ClusterRole and ClusterRoleBinding instead of Role and RoleBinding. 

closes #32 