### PR TITLE
Update apiextensions.k8s.io in app.terraform.io_workspaces_crd.yaml

### DIFF
--- a/crds/app.terraform.io_workspaces_crd.yaml
+++ b/crds/app.terraform.io_workspaces_crd.yaml
@@ -1,6 +1,6 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:


### PR DESCRIPTION
Kubernetes 1.22 deprecated apiextensions.k8s.io/v1beta1.

```
Error: failed to install CRD crds/app.terraform.io_workspaces_crd.yaml: unable to recognize "": no matches for kind "CustomResourceDefinition" in version "apiextensions.k8s.io/v1beta1"
```