### PR TITLE
Add nodeSelector

### DIFF
--- a/templates/sync-workspace-deployment.yaml
+++ b/templates/sync-workspace-deployment.yaml
@@ -90,6 +90,10 @@ spec:
             periodSeconds: 5
             successThreshold: 1
             timeoutSeconds: 5
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         {{- if .Values.CACerts}}
         - name: cacert

--- a/values.yaml
+++ b/values.yaml
@@ -75,3 +75,5 @@ tests:
 # CACerts can be set like this:
 # helm install <other parameters> --set-file CACerts=/path/to/certs.pem
 CACerts: ""
+
+nodeSelector: {}


### PR DESCRIPTION
Adds `nodeSelector` so we can schedule the operator in a specific node.

Defaults to an empty hash, ie no scheduling restrictions