### PR TITLE
feat: remove --k8s-watch-namespace= from binary args so that all name…

### DIFF
--- a/templates/sync-workspace-deployment.yaml
+++ b/templates/sync-workspace-deployment.yaml
@@ -66,7 +66,6 @@ spec:
             - /bin/terraform-k8s
           args:
             - --enable-leader-election
-            - --k8s-watch-namespace={{ default .Release.Namespace .Values.syncWorkspace.k8WatchNamespace}}
             {{- if .Values.syncWorkspace.logLevel }}
             - --zap-log-level={{ .Values.syncWorkspace.logLevel }}
             {{- end }}


### PR DESCRIPTION
…spaces can be used