### PR TITLE
[TK-1955] Update Docker image tag to 1.1.2

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: terraform
-version: 1.1.1
+version: 1.1.2
 description: Install and configure Terraform Cloud Operator on Kubernetes.
 home: https://www.terraform.io
 sources:

--- a/values.yaml
+++ b/values.yaml
@@ -11,7 +11,7 @@ global:
   # imageK8S is the name (and tag) of the terraform-k8s Docker image that
   # is used for functionality such as workspace sync. This can be overridden
   # per component.
-  imageK8S: "hashicorp/terraform-k8s:1.1.1"
+  imageK8S: "hashicorp/terraform-k8s:1.1.2"
 
 # syncWorkspace will run the workspace sync process to sync K8S Workspaces with
 # Terraform Cloud workspaces.


### PR DESCRIPTION
### Description

This PR updates Docker image tag to `1.1.2`.

### Release Note
```
NONE
```

### Community Note
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment