### PR TITLE
Updated CRD to add workingDirectory 

### DIFF
--- a/crds/app.terraform.io_workspaces_crd.yaml
+++ b/crds/app.terraform.io_workspaces_crd.yaml
@@ -285,6 +285,9 @@ spec:
                 - repo_identifier
                 - token_id
                 type: object
+              workingDirectory:
+                description: Working directory within the module repository
+                type: string
             required:
             - organization
             - secretsMountPath


### PR DESCRIPTION
refers to https://github.com/hashicorp/terraform-k8s/pull/156

This PR adds the corresponding update to the CRD in terraform-k8s, adding support for setting the working directory on a workspace.