### PR TITLE
Swap helm charts call to Github actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,12 +27,19 @@ jobs:
               exit 1
             fi
       - run:
+          name: install gh tool
+          command: |
+            version="2.22.1"
+            curl --show-error --silent --location --output "gh.tar.gz" "https://github.com/cli/cli/releases/download/v${version}/gh_${version}_linux_amd64.tar.gz"
+            tar -xvzf gh.tar.gz && mkdir -p bin && mv "gh_${version}_linux_amd64/bin/gh" bin/
+            
+      - run:
           name: update helm-charts index
           command: |
             export GITHUB_TOKEN="${HELM_CHARTS_GITHUB_TOKEN}"
             gh workflow run .github/workflows/publish-charts.yml \
               --repo hashicorp/helm-charts \
-              --ref templates_default_test \
+              --ref main \
               -f SOURCE_TAG="${CIRCLE_TAG}" \
               -f SOURCE_REPO="${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}"
       - slack/status:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,12 +29,12 @@ jobs:
       - run:
           name: update helm-charts index
           command: |
-            curl --show-error --silent --fail --user "${CIRCLE_TOKEN}:" \
-                -X POST \
-                -H 'Content-Type: application/json' \
-                -H 'Accept: application/json' \
-                -d "{\"branch\": \"main\",\"parameters\":{\"SOURCE_REPO\": \"${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}\",\"SOURCE_TAG\": \"${CIRCLE_TAG}\"}}" \
-                "${CIRCLE_ENDPOINT}/${CIRCLE_PROJECT}/pipeline"
+            export GITHUB_TOKEN="${HELM_CHARTS_GITHUB_TOKEN}"
+            gh workflow run .github/workflows/publish-charts.yml \
+              --repo hashicorp/helm-charts \
+              --ref templates_default_test \
+              -f SOURCE_TAG="${CIRCLE_TAG}" \
+              -f SOURCE_REPO="${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}"
       - slack/status:
           fail_only: true
           failure_message: "Failed to trigger an update to the helm charts index. Check the logs at: ${CIRCLE_BUILD_URL}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
           name: update helm-charts index
           command: |
             export GITHUB_TOKEN="${HELM_CHARTS_GITHUB_TOKEN}"
-            gh workflow run .github/workflows/publish-charts.yml \
+            ./bin/gh workflow run .github/workflows/publish-charts.yml \
               --repo hashicorp/helm-charts \
               --ref main \
               -f SOURCE_TAG="${CIRCLE_TAG}" \


### PR DESCRIPTION
The helm-charts publishing job was migrated from CircleCI to GitHub Actions and this reflects that change.