### PR TITLE
Add the "resources" specification to sync-workspace-deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.3 (November 27, 2023)
+
+* Add `resource` specification in deployment manifest
+
 ## 1.1.2 (November 22, 2022)
 
 * Update operator image to `v1.1.2`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.1.3 (November 27, 2023)
+## 1.1.3 (December 27, 2023)
 
 * Add `resource` specification in deployment manifest
 

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: terraform
-version: 1.1.2
+version: 1.1.3
 description: Install and configure Terraform Cloud Operator on Kubernetes.
 home: https://www.terraform.io
 sources:

--- a/templates/sync-workspace-deployment.yaml
+++ b/templates/sync-workspace-deployment.yaml
@@ -90,6 +90,10 @@ spec:
             periodSeconds: 5
             successThreshold: 1
             timeoutSeconds: 5
+          {{- if .Values.syncWorkspace.resources }}
+          resources:
+            {{- toYaml .Values.syncWorkspace.resources | nindent 12 }}
+          {{- end }}
       volumes:
         {{- if .Values.CACerts}}
         - name: cacert

--- a/values.yaml
+++ b/values.yaml
@@ -59,6 +59,14 @@ syncWorkspace:
   sensitiveVariables:
     secretName: workspacesecrets
 
+  # Resources to allocate for the workspace container in the operator pod
+  # resources:
+  #   requests:
+  #     cpu: 50m
+  #     memory: 128Mi
+  #   limits:
+  #     memory: 128Mi
+
 # Control whether a test Pod manifest is generated when running helm template.
 # When using helm install, the test Pod is not submitted to the cluster so this
 # is only useful when running helm template.


### PR DESCRIPTION
In the `sync-workspace-deployment.yaml` deployment, there is currently no resource specification, leaving the `terraform-sync-workspace` container unrestricted in terms of CPU and memory consumption in Kubernetes clusters.

In this pull request, I have added the ability to specify explicit resource limits through `.Values.syncWorkspace.resources` in the `sync-workspace-deployment.yaml` template. If this parameter is not explicitly defined in `values.yaml`, no resource specification will be applied.

[Values example](https://github.com/obervinov/terraform-helm/blob/feature/deployment-resources-spec/values.yaml#L62-L68) and [template](https://github.com/obervinov/terraform-helm/blob/feature/deployment-resources-spec/templates/sync-workspace-deployment.yaml#L93-L96).